### PR TITLE
Removed "display.h" that caused issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
 # y-board-mic-speakers
+Removes "display.h" to avoid conflicts in rbtree.h and fastspi.h

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,5 @@
 #include "Arduino.h"
 #include "coefficients.h"
-#include "display.h"
 #include "tone_gen.h"
 #include "yboard.h"
 


### PR DESCRIPTION
The main.cpp file had #include "display.h", which references external libraries that have since changed. This change removes "display.h", which has no effect on the functionality but leads to the buggy code not being compiled.